### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/qbee-io/qbee-usecases/security/code-scanning/1](https://github.com/qbee-io/qbee-usecases/security/code-scanning/1)

To fix the issue, explicitly add a `permissions` block that restricts the default privileges of the workflow or individual jobs. The block should ideally grant only the privileges required for successful completion of the workflow's steps; for most CI/CD workflows, `contents: read` is a sensible default starting point. This block can be added either at the root of the workflow (to affect all jobs) or within specific jobs if more granular control is desired. Here, adding it at the root (just after `name: CI`, before `on:`) keeps things clear and secure, ensuring that all jobs within the workflow only receive the stated permissions unless overridden. No new imports or definitions are required—just the addition of the `permissions` block.

**File/region to change:**  
- `.github/workflows/main.yml`, at the root level, after `name: CI` and before `on:`.

**What is needed:**  
- Add a `permissions:` block with the least privileges required (start with `contents: read`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
